### PR TITLE
Support for auxiliary inputs

### DIFF
--- a/code/datamodules.py
+++ b/code/datamodules.py
@@ -3,7 +3,7 @@
 import warnings
 from argparse import ArgumentParser
 from os.path import dirname, join
-from typing import Optional, Union
+from typing import Optional, Union, Any
 
 import numpy as np
 import pandas as pd
@@ -62,6 +62,14 @@ class DMSDataModule(pl.LightningDataModule):
         parser.add_argument("--target_offset",
                             help="an offset to add to every target value in the dataset",
                             type=float, default=0)
+        parser.add_argument("--aux_input_names",
+                            help="the names of the auxiliary inputs which the model can access at any layer",
+                            type=str, default=None)
+        parser.add_argument("--aux-formats",
+                            help="Comma-separated list of aux input formats, e.g. 'feat1=tensor,feat2=numpy,feat3=string'."
+                                 " Valid formats are 'tensor', 'numpy', and 'string'. If not specified, all numerical aux inputs"
+                                 " will be converted to tensors, and all string aux inputs will be left as strings.",
+                            type=str, default="")
         parser.add_argument("--split_dir",
                             help="the directory containing the train/tune/test split",
                             type=str, default=None)
@@ -105,6 +113,8 @@ class DMSDataModule(pl.LightningDataModule):
                  target_roll: int = 0,
                  standardize_targets: bool = False,
                  target_offset: float = 0,
+                 aux_input_names: Optional[Union[str, list[str], tuple[str]]] = None,
+                 aux_formats: Optional[str] = None,
                  train_name: str = "train",
                  val_name: str = "val",
                  test_name: str = "test",
@@ -117,6 +127,8 @@ class DMSDataModule(pl.LightningDataModule):
 
         # basic dataset and encoding info
         self.ds_name = ds_name
+        # load dataset metadata
+        self.ds_metadata = utils.load_dataset_metadata()[self.ds_name]
         self.pdb_fn = None
         self._init_pdb_fn(pdb_fn)
 
@@ -182,14 +194,16 @@ class DMSDataModule(pl.LightningDataModule):
             warnings.warn("detected rosetta encoding, calculating standardization parameters for input features")
             self._calc_input_standardize_params()
 
+        # set up auxiliary inputs
+        self.aux_input_names = None
+        self._init_aux_input_names(aux_input_names)
+        self.aux_input_formats = self.parse_aux_formats(aux_formats)
+
         # initialize DMSDataset that are used later in this module to load dataloaders, etc
         self.train_ds = None
         self.val_ds = None
         self.test_ds = None
         self.full_ds = None
-
-        # load dataset metadata
-        self.ds_metadata = utils.load_dataset_metadata()[self.ds_name]
 
         # amino acid sequence length
         self.aa_seq_len = len(self.ds_metadata["wt_aa"])
@@ -199,10 +213,14 @@ class DMSDataModule(pl.LightningDataModule):
         self.example_input_array = None
         self.aa_encoding_len = None
         self.seq_encoding_len = None
-        sample_batch = self.get_sample_batch()
-        if sample_batch is not None:
-            self._init_example_input_array(sample_batch)
-            self._init_encoding_lens(sample_batch)
+        sample_encoded_data_batch = self.get_sample_encoded_data_batch()
+        sample_aux_batch = self.get_sample_aux_batch()
+        if sample_encoded_data_batch is not None:
+            self._init_encoding_lens(sample_encoded_data_batch)
+            self._init_example_input_array(
+                sample_encoded_data_batch,
+                sample_aux_batch
+            )
 
     def _init_pdb_fn(self, pdb_fn):
         if pdb_fn == "auto":
@@ -210,35 +228,56 @@ class DMSDataModule(pl.LightningDataModule):
         else:
             self.pdb_fn = pdb_fn
 
-    def _init_example_input_array(self, sample_batch):
-        # example input array helps with sanity checking and printing full model summaries
-        self.example_input_array = {"x": torch.from_numpy(sample_batch), "pdb_fn": self.pdb_fn}
+    def _init_example_input_array(
+            self,
+            sample_encoded_data_batch: np.ndarray,
+            sample_aux_batch: Optional[dict[str, Any]]) -> None:
 
-    def get_sample_batch(self):
-        """ compute a sample batch of encoded data used for example input array, sequence encoding lengths, etc """
-        # encode a full batch of variants to get the encoding length (the last dim) and an example_input_array
+        # example input array helps with sanity checking
+        # and printing full model summaries
+        example_input_array = {
+            "x": torch.from_numpy(sample_encoded_data_batch),
+            "pdb_fn": self.pdb_fn
+        }
+
+        if sample_aux_batch is not None:
+            example_input_array.update(sample_aux_batch)
+
+        self.example_input_array = example_input_array
+
+    def get_sample_encoded_data_batch(self) -> np.ndarray:
+        """ compute a sample batch of encoded data used for example input array,
+            sequence encoding lengths, etc """
+
+        # encode a full batch of variants to get the encoding
+        # length (the last dim) and an example_input_array
         variants = self.ds.iloc[0:self.batch_size]["variant"].tolist()
         return self.get_encoded_variants(variants)
 
-    def _init_encoding_lens(self, sample_batch):
-        if sample_batch is None:
+    def get_sample_aux_batch(self) -> Optional[dict[str, Any]]:
+        """ compute a sample batch of auxiliary data used for example input array """
+        batch_idxs = np.arange(self.batch_size)
+        return self._get_aux_inputs_for_idxs(batch_idxs)
+
+    def _init_encoding_lens(self, sample_encoded_data_batch: np.ndarray) -> None:
+        if sample_encoded_data_batch is None:
             # encoding length stuff is extra, only used for METL models, so give option not to compute it
             warnings.warn("Unable to compute aa_encoding_len and seq_encoding_len because sample_batch is None")
             return
-        if len(sample_batch.shape) not in [2, 3]:
-            raise ValueError("temp_enc_variant has an unknown shape: {}".format(sample_batch.shape))
-        elif len(sample_batch.shape) == 2:
+        if len(sample_encoded_data_batch.shape) not in [2, 3]:
+            raise ValueError("temp_enc_variant has an unknown shape: {}".format(sample_encoded_data_batch.shape))
+        elif len(sample_encoded_data_batch.shape) == 2:
             # if 2 dimensions, then it's a seq-level encoding (batch_size, encoded_seq)
             self.aa_encoding_len = 0
-            self.seq_encoding_len = sample_batch.shape[-1]
-        elif len(sample_batch.shape) == 3:
+            self.seq_encoding_len = sample_encoded_data_batch.shape[-1]
+        elif len(sample_encoded_data_batch.shape) == 3:
             # if 3 dimensions, then it's an amino-acid level encoding (batch_size, aa_seq_len, enc_len)
-            self.aa_encoding_len = sample_batch.shape[-1]
+            self.aa_encoding_len = sample_encoded_data_batch.shape[-1]
             self.seq_encoding_len = self.aa_seq_len * self.aa_encoding_len
             # an additional validation check just in case
-            if self.aa_seq_len != sample_batch.shape[-2]:
+            if self.aa_seq_len != sample_encoded_data_batch.shape[-2]:
                 raise ValueError("expected aa_seq_len to be {}, but temp_enc_variant is {}".format(
-                    self.aa_seq_len, sample_batch.shape[-2]))
+                    self.aa_seq_len, sample_encoded_data_batch.shape[-2]))
 
     def _auto_test_name(self, test_name):
         if test_name != "auto":
@@ -283,7 +322,7 @@ class DMSDataModule(pl.LightningDataModule):
         self.target_names = target_names
         self.num_tasks = len(self.target_names)
 
-    def _calc_target_standardize_params(self):
+    def _calc_target_standardize_params(self) -> None:
         """ calculate the means and standard deviations of all energy terms for the train set """
         # if there is no split... standardize using the full dataset, but throw a warning just in case
         if self.split_idxs is None:
@@ -343,6 +382,39 @@ class DMSDataModule(pl.LightningDataModule):
         self.input_standardize_means = np.concatenate(standardize_means)
         self.input_standardize_stds = np.concatenate(standardize_stds)
 
+    def _init_aux_input_names(
+            self,
+            aux_input_names: Optional[Union[str, list[str], tuple[str]]]) -> None:
+
+        if aux_input_names is None:
+            return
+
+        # if the auxiliary input names are a string or tuple, convert to a list
+        if isinstance(aux_input_names, str):
+            aux_input_names = [aux_input_names]
+        elif isinstance(aux_input_names, tuple):
+            aux_input_names = list(aux_input_names)
+
+        # verify all the auxiliary input names are in the dataset
+        for ain in aux_input_names:
+            if ain not in self.ds:
+                raise ValueError("auxiliary input not found in dataset: {}".format(ain))
+
+        self.aux_input_names = aux_input_names
+
+    @staticmethod
+    def parse_aux_formats(s: str) -> dict[str, str]:
+        if not s:
+            return {}
+        out = {}
+        for item in s.split(","):
+            key, val = item.split("=")
+            val = val.strip().lower()
+            if val not in ("tensor", "numpy", "string"):
+                raise ValueError(f"invalid format '{val}' for aux input '{key.strip()}'")
+            out[key.strip()] = val
+        return out
+
     def prepare_data(self):
         # prepare_data is called from a single GPU. Do not use it to assign state (self.x = y).
         pass
@@ -356,14 +428,18 @@ class DMSDataModule(pl.LightningDataModule):
         return variants
 
     @staticmethod
-    def _standardize(data, means, stds):
+    def _standardize(data: np.ndarray,
+                     means: np.ndarray,
+                     stds: np.ndarray) -> np.ndarray:
+
         if means is None or stds is None:
             raise ValueError("need to standardize, but standardize params are None")
 
-        standardized_data = np.divide((data - means), stds, out=np.zeros_like(data), where=stds != 0)
+        standardized_data = np.divide((data - means), stds, out=np.zeros_like(data),
+                                      where=stds != 0)
         return standardized_data
 
-    def _standardize_inputs(self, data):
+    def _standardize_inputs(self, data: np.ndarray) -> np.ndarray:
         """ perform standardization of rosetta energies using the given means and standard deviations """
         if self.input_standardize_means is None or self.input_standardize_stds is None:
             raise ValueError("need to standardize rosetta encoded data, but standardize params are None")
@@ -376,11 +452,20 @@ class DMSDataModule(pl.LightningDataModule):
         targets = self._standardize(data, self.target_standardize_means, self.target_standardize_stds)
         return targets
 
-    def _get_raw_encoded_variants(self, variants: list[str], concat: bool = True):
-        enc_data = enc.encode(encoding=self.encoding, variants=variants, ds_name=self.ds_name, concat=concat)
+    def _get_raw_encoded_variants(
+            self,
+            variants: list[str],
+            concat: bool = True) -> np.ndarray:
+
+        enc_data = enc.encode(
+            encoding=self.encoding,
+            variants=variants,
+            ds_name=self.ds_name,
+            concat=concat
+        )
         return enc_data
 
-    def get_encoded_variants(self, variants: list[str]):
+    def get_encoded_variants(self, variants: list[str]) -> np.ndarray:
         enc_data = self._get_raw_encoded_variants(variants, concat=True)
 
         # standardize if using rosetta encoding
@@ -396,12 +481,11 @@ class DMSDataModule(pl.LightningDataModule):
         variants = self.get_variants(set_name)
         return self._get_raw_encoded_variants(variants, concat=concat)
 
-    def get_encoded_data(self, set_name: Optional[str]):
-        # print("Encoding data for set: {}".format(set_name))
+    def get_encoded_data(self, set_name: Optional[str]) -> np.ndarray:
         variants = self.get_variants(set_name)
         return self.get_encoded_variants(variants)
 
-    def _get_raw_targets(self, set_name: Optional[str]):
+    def _get_raw_targets(self, set_name: Optional[str]) -> Optional[np.ndarray]:
         if self.target_names is None:
             return None
 
@@ -413,7 +497,11 @@ class DMSDataModule(pl.LightningDataModule):
 
         return targets
 
-    def get_targets(self, set_name: Optional[str], squeeze: bool = False):
+    def get_targets(
+            self,
+            set_name: Optional[str],
+            squeeze: bool = False) -> Optional[np.ndarray]:
+
         targets = self._get_raw_targets(set_name)
         if targets is None:
             return None
@@ -432,6 +520,50 @@ class DMSDataModule(pl.LightningDataModule):
             targets = targets.squeeze()
 
         return targets
+
+    def _get_aux_inputs_for_idxs(self, idxs: np.ndarray) -> Optional[dict[str, Any]]:
+        if self.aux_input_names is None:
+            return None
+
+        aux_inputs = {}
+        for ain in self.aux_input_names:
+            col = self.ds.iloc[idxs][ain]
+
+            if ain in self.aux_input_formats:
+                # if a format is specified for this auxiliary input, use it
+                fmt = self.aux_input_formats[ain]
+            elif pd.api.types.is_numeric_dtype(col):
+                # otherwise default to pytorch tensor if column is numeric
+                fmt = "tensor"
+            else:
+                fmt = "string"
+
+            if fmt == "tensor":
+                if not pd.api.types.is_numeric_dtype(col):
+                    raise TypeError(
+                        f"Cannot convert non-numeric column '{ain}' to tensor.")
+                aux_inputs[ain] = torch.from_numpy(col.to_numpy())
+            elif fmt == "numpy":
+                if not pd.api.types.is_numeric_dtype(col):
+                    raise TypeError(
+                        f"Cannot convert non-numeric column '{ain}' to numpy array.")
+                aux_inputs[ain] = col.to_numpy()
+            elif fmt == "string":
+                aux_inputs[ain] = col.tolist()
+            else:
+                raise ValueError(f"Invalid aux input format '{fmt}' for column '{ain}'")
+
+        return aux_inputs
+
+    def get_aux_inputs(self, set_name: Optional[str]) -> Optional[dict[str, Any]]:
+        if set_name is None:
+            # get indexes for the entire dataset
+            idxs = np.arange(len(self.ds))
+        else:
+            # get indexes for the given set name
+            idxs = self.get_split_idxs(set_name)
+
+        return self._get_aux_inputs_for_idxs(idxs)
 
     def has_set(self, set_name: str, user_set_name: bool = False):
         if self.split_idxs is None:
@@ -462,13 +594,17 @@ class DMSDataModule(pl.LightningDataModule):
         if set_name == "_wt":
             targets = None
             enc_data = self.get_encoded_variants(["_wt"])
+            # todo: how should we handle the auxiliary inputs for the wild-type variant?
+            aux_inputs = None
         else:
             targets = self.get_targets(set_name)
             enc_data = self.get_encoded_data(set_name)
+            aux_inputs = self.get_aux_inputs(set_name)
 
         torch_ds = datasets.DMSDataset(inputs=torch.from_numpy(enc_data),
                                        targets=None if targets is None else torch.from_numpy(targets),
-                                       pdb_fn=self.pdb_fn)
+                                       pdb_fn=self.pdb_fn,
+                                       aux_inputs=aux_inputs)
         return torch_ds
 
     def setup(self, stage=None):
@@ -537,6 +673,8 @@ class DMSDataModule(pl.LightningDataModule):
             return self._get_dataloader(self.full_ds)
         elif self.predict_mode == "wt":
             return self._get_dataloader(self.wt_ds)
+        else:
+            raise ValueError("unknown predict mode: {}".format(self.predict_mode))
 
 
 class RosettaDataModule(pl.LightningDataModule):

--- a/code/datamodules.py
+++ b/code/datamodules.py
@@ -241,7 +241,8 @@ class DMSDataModule(pl.LightningDataModule):
         }
 
         if sample_aux_batch is not None:
-            example_input_array.update(sample_aux_batch)
+            # group aux inputs into their own dictionary
+            example_input_array["aux"] = sample_aux_batch
 
         self.example_input_array = example_input_array
 

--- a/code/datamodules.py
+++ b/code/datamodules.py
@@ -64,7 +64,7 @@ class DMSDataModule(pl.LightningDataModule):
                             type=float, default=0)
         parser.add_argument("--aux_input_names",
                             help="the names of the auxiliary inputs which the model can access at any layer",
-                            type=str, default=None)
+                            type=str, nargs="+", default=None)
         parser.add_argument("--aux-formats",
                             help="Comma-separated list of aux input formats, e.g. 'feat1=tensor,feat2=numpy,feat3=string'."
                                  " Valid formats are 'tensor', 'numpy', and 'string'. If not specified, all numerical aux inputs"

--- a/code/datasets.py
+++ b/code/datasets.py
@@ -66,9 +66,10 @@ class DMSDataset(torch.utils.data.Dataset):
         if self.pdb_fn is not None:
             out_dict["pdb_fns"] = self.pdb_fn
 
+        # group auxiliary inputs into a dictionary
         if self.aux_inputs is not None:
-            for key, value in self.aux_inputs.items():
-                out_dict[key] = value[index]
+            aux = {k: v[index] for k, v in self.aux_inputs.items()}
+            out_dict["aux"] = aux
 
         return out_dict
 

--- a/code/datasets.py
+++ b/code/datasets.py
@@ -2,7 +2,7 @@
 
 from os.path import dirname, join, isdir
 import sqlite3
-from typing import Optional
+from typing import Optional, Any
 
 import numpy as np
 import pandas as pd
@@ -40,14 +40,22 @@ def load_standardization_params(split_dir, train_only=True):
 
 
 class DMSDataset(torch.utils.data.Dataset):
-    """ Dataset for DMS data, in-memory, similar to PyTorch's TensorDataset, but support for PDB fn
-        and dictionary return value """
+    """ Dataset for DMS data, in-memory, similar to PyTorch's TensorDataset,
+        but support for PDB fn, auxiliary inputs, and dictionary return value """
 
-    def __init__(self, inputs: Tensor, targets: Tensor, pdb_fn: str = None) -> None:
-        # DMS datasets only support one PDB_fn for the whole dataset, so pdb_fn is a single string
+    def __init__(
+            self,
+            inputs: Tensor,
+            targets: Tensor,
+            pdb_fn: str = None,
+            aux_inputs: dict[str, Any] = None) -> None:
+
+        # DMS datasets only support one PDB_fn for the whole dataset
+        # so pdb_fn is a single string
         self.inputs = inputs
         self.targets = targets
         self.pdb_fn = pdb_fn
+        self.aux_inputs = aux_inputs
 
     def __getitem__(self, index):
         out_dict = {"inputs": self.inputs[index]}
@@ -57,6 +65,10 @@ class DMSDataset(torch.utils.data.Dataset):
 
         if self.pdb_fn is not None:
             out_dict["pdb_fns"] = self.pdb_fn
+
+        if self.aux_inputs is not None:
+            for key, value in self.aux_inputs.items():
+                out_dict[key] = value[index]
 
         return out_dict
 

--- a/code/models.py
+++ b/code/models.py
@@ -1094,36 +1094,6 @@ class TransferModel(nn.Module):
         return self.model(x, **kwargs)
 
 
-class LayerThatAcceptsAuxInputs(nn.Module):
-    """ simple module that allows auxiliary inputs """
-    def forward(self, x, **kwargs):
-        print("Module: {}".format(self.__class__.__name__))
-        print("Aux inputs: {}".format(kwargs.keys()))
-
-
-class LayerThatDoesNotAcceptAuxInputs(nn.Module):
-    def forward(self, x):
-        # if aux inputs / additional kwargs are passed in, the script will crash
-        # here because this forward function does not accept them
-        print("Module: {}".format(self.__class__.__name__))
-
-
-class AuxiliaryInputsTestModel(nn.Module):
-    """ a simple model for testing auxiliary inputs  """
-
-    def __init__(self, *args, **kwargs):
-        super().__init__()
-
-        self.model = SequentialWithArgs(
-            LayerThatAcceptsAuxInputs(),
-            LayerThatDoesNotAcceptAuxInputs()
-        )
-
-    def forward(self, x, **kwargs):
-        output = self.model(x, **kwargs)
-        return output
-
-
 def get_activation_fn(activation, functional=True):
     if activation == "relu":
         return F.relu if functional else nn.ReLU()
@@ -1148,7 +1118,6 @@ class Model(enum.Enum):
         self.cls = cls
         self.transfer_model = transfer_model
 
-    aux = AuxiliaryInputsTestModel, False
     linear = LRModel, False
     fully_connected = FCModel, False
     cnn = ConvModel, False

--- a/code/relative_attention.py
+++ b/code/relative_attention.py
@@ -494,7 +494,7 @@ class RelativeTransformerEncoder(nn.Module):
         if reset_params:
             self.apply(models.reset_parameters_helper)
 
-    def forward(self, src: Tensor, pdb_fn=None) -> Tensor:
+    def forward(self, src: Tensor, pdb_fn=None, **kwargs) -> Tensor:
         output = src
 
         for mod in self.layers:

--- a/code/tasks.py
+++ b/code/tasks.py
@@ -267,12 +267,17 @@ class DMSTask(pl.LightningModule):
     def _shared_step(self, data_batch, batch_idx, compute_loss=True):
         inputs = data_batch["inputs"]
         labels = data_batch["targets"]
+
         # the pdb file if one is provided by the dataloader (for relative position 3D)
         # we only support one pdb file per batch, so just choose the first one (index 0)
         # in the future, if we support multiple per batch, we can pass in all the pdb files
         pdb_fn = data_batch["pdb_fns"][0] if "pdb_fns" in data_batch else None
 
-        outputs = self(inputs, pdb_fn=pdb_fn)
+        # auxiliary inputs for the model
+        # if they are not provided, we just pass in an empty dictionary
+        aux = data_batch.get("aux", {})
+
+        outputs = self(inputs, pdb_fn=pdb_fn, **aux)
         if compute_loss:
             loss = F.mse_loss(outputs, labels)
             return outputs, loss

--- a/code/utils.py
+++ b/code/utils.py
@@ -136,6 +136,10 @@ def load_dataset(ds_name: Optional[str] = None,
         # merge epistasis data with dataset
         ds = pd.merge(ds, epistasis_df, on="variant", how="left")
 
+    # downcast all float64 columns to float32
+    for col in ds.select_dtypes(include=["float64"]).columns:
+        ds[col] = ds[col].astype("float32")
+
     return ds
 
 


### PR DESCRIPTION
Adding new feature to allow auxiliary inputs to be passed to network modules as keyword arguments in `forward()`. 

- Auxiliary data is placed in the main `.tsv` file for the dataset. The typical columns in that file are `variant`, `num_mutations`, and `score`. You can add columns for `aux1`, `aux2`, etc.. In practice, the column names should probably be more descriptive, for example something like `parent_id` instead of `aux1`. Multiple aux columns are supported. Integers, floats, and strings are supported, but a single column should not mix datatypes. 
- There are new arguments in `train_target_model.py` which allow you to specify auxiliary inputs. The main argument is `--aux_input_names`. This is where you can specify the names of the auxiliary data columns. So you would call the script with `—aux_input_names aux1 aux2` to specify that the information in columns `aux1` and `aux2` should be passed in to the model layers. The other argument is `--aux-formats` which allows you to specify the data type of each aux column, either `tensor`, `numpy`, or `string`. By default, numerical columns are fed through the network as PyTorch tensors. This is what you want if you’re using the auxiliary information in calls to PyTorch functions like for computing loss. You have the option to specify ‘numpy’ if you want a particular column fed through the network as a NumPy array. You may want this if you’re using the auxiliary data in Python control flow or on the CPU side of the processing rather than the GPU side.
- You need to set up your network architecture to accept the auxiliary inputs. There are 2 components to this. First, your model layers need to be wrapped in my custom `SequentialWithArgs` module instead of the PyTorch default `nn.Sequential` module. My `SequentialWithArgs` module, which is a subclass of `nn.Sequential`, has custom logic to accept in and pass along keyword arguments to any model layers which accept keyword arguments. This is how the auxiliary information is passed along to model layers. The second component to the network architecture is to make sure that your custom layer, which needs the auxiliary information, accepts keyword arguments in its forward function. 
- If you’re modifying my `AttnModel` or `TransferModel` classes, they are already wrapped in `SequentialWithArgs`. So all you’d have to do is add your new layer, which accepts `kwargs` in its `forward()` function, and your new layer should be able to access the auxiliary information automatically. 
- Auxiliary inputs are only supported for experimental data / finetuning, not for pretraining.