### PR TITLE
Update Python version to 3.9.17 in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: metl
 channels:
   - conda-forge
 dependencies:
-  - python=3.9.13
+  - python=3.9.17
   - pytorch::pytorch=1.12.1
   - pytorch-lightning=1.7.7
   - torchmetrics=0.10.2


### PR DESCRIPTION
Workaround that may help correct
```
OSError: [Errno 98] Address already in use
```
when trying to run multi-GPU DDP training w/ PyTorch Lightning. This was observed when multiple HTCondor jobs land on the same server. It originally happened with multi-GPU jobs but may affect single-GPU jobs as well.